### PR TITLE
Skippatches

### DIFF
--- a/gogrepo.py
+++ b/gogrepo.py
@@ -465,6 +465,7 @@ def process_argv(argv):
     g1.add_argument('-dryrun', action='store_true', help='display, but skip downloading of any files')
     g1.add_argument('-skipextras', action='store_true', help='skip downloading of any GOG extra files')
     g1.add_argument('-skipgames', action='store_true', help='skip downloading of any GOG game files')
+    g1.add_argument('-skippatches', action='store_true', help='skip downloading of any game patches')
     g1.add_argument('-id', action='store', help='id of the game in the manifest to download')
     g1.add_argument('-wait', action='store', type=float,
                     help='wait this long in hours before starting', default=0.0)  # sleep in hr
@@ -774,7 +775,7 @@ def cmd_import(src_dir, dest_dir):
             shutil.copy(f, dest_file)
 
 
-def cmd_download(savedir, skipextras, skipgames, skipids, dryrun, id):
+def cmd_download(savedir, skipextras, skipgames, skippatches, skipids, dryrun, id):
     sizes, rates, errors = {}, {}, {}
     work = Queue()  # build a list of work items
 
@@ -818,6 +819,9 @@ def cmd_download(savedir, skipextras, skipgames, skipids, dryrun, id):
 
         if skipgames:
             item.downloads = []
+
+        if skippatches:
+            item.downloads = [d for d in item.downloads if not d["name"].startswith("patch_")]
 
         # Generate and save a game info text file
         if not dryrun:
@@ -1164,7 +1168,7 @@ def main(args):
         if args.wait > 0.0:
             info('sleeping for %.2fhr...' % args.wait)
             time.sleep(args.wait * 60 * 60)
-        cmd_download(args.savedir, args.skipextras, args.skipgames, args.skipids, args.dryrun, args.id)
+        cmd_download(args.savedir, args.skipextras, args.skipgames, args.skippatches, args.skipids, args.dryrun, args.id)
     elif args.cmd == 'import':
         cmd_import(args.src_dir, args.dest_dir)
     elif args.cmd == 'verify':

--- a/gogrepo.py
+++ b/gogrepo.py
@@ -490,6 +490,9 @@ def process_argv(argv):
     g1.add_argument('cleandir', action='store', help='root directory containing gog games to be cleaned')
     g1.add_argument('-dryrun', action='store_true', help='do not move files, only display what would be cleaned')
 
+    g1 = sp1.add_parser('list', help='List all games from the local GOG library')
+
+
     g1 = p1.add_argument_group('other')
     g1.add_argument('-h', '--help', action='help', help='show help message and exit')
     g1.add_argument('-v', '--version', action='version', help='show version number and exit',
@@ -1135,6 +1138,20 @@ def cmd_clean(cleandir, dryrun):
         info('nothing to clean. nice and tidy!')
 
 
+def cmd_list():
+    """list all games from the manifest"""
+    info("List all games from the local GOG library")
+    gamesdb = load_manifest()
+    output_format = "{id:12}\t{title:40}\t{long_title:28}"
+    # output a header row with uppercase keys as column headers
+    print(output_format.format(
+        **{key: key.replace("_", " ").upper() for key in gamesdb[0].keys()})
+    )
+
+    for game in sorted(gamesdb, key=lambda g: g.title):
+        print(output_format.format(**game))
+
+
 def main(args):
     stime = datetime.datetime.now()
 
@@ -1159,6 +1176,8 @@ def main(args):
         cmd_backup(args.src_dir, args.dest_dir)
     elif args.cmd == 'clean':
         cmd_clean(args.cleandir, args.dryrun)
+    elif args.cmd == 'list':
+        cmd_list()
 
     etime = datetime.datetime.now()
     info('--')

--- a/gogrepo.py
+++ b/gogrepo.py
@@ -491,9 +491,6 @@ def process_argv(argv):
     g1.add_argument('cleandir', action='store', help='root directory containing gog games to be cleaned')
     g1.add_argument('-dryrun', action='store_true', help='do not move files, only display what would be cleaned')
 
-    g1 = sp1.add_parser('list', help='List all games from the local GOG library')
-
-
     g1 = p1.add_argument_group('other')
     g1.add_argument('-h', '--help', action='help', help='show help message and exit')
     g1.add_argument('-v', '--version', action='version', help='show version number and exit',
@@ -1142,20 +1139,6 @@ def cmd_clean(cleandir, dryrun):
         info('nothing to clean. nice and tidy!')
 
 
-def cmd_list():
-    """list all games from the manifest"""
-    info("List all games from the local GOG library")
-    gamesdb = load_manifest()
-    output_format = "{id:12}\t{title:40}\t{long_title:28}"
-    # output a header row with uppercase keys as column headers
-    print(output_format.format(
-        **{key: key.replace("_", " ").upper() for key in gamesdb[0].keys()})
-    )
-
-    for game in sorted(gamesdb, key=lambda g: g.title):
-        print(output_format.format(**game))
-
-
 def main(args):
     stime = datetime.datetime.now()
 
@@ -1180,8 +1163,6 @@ def main(args):
         cmd_backup(args.src_dir, args.dest_dir)
     elif args.cmd == 'clean':
         cmd_clean(args.cleandir, args.dryrun)
-    elif args.cmd == 'list':
-        cmd_list()
 
     etime = datetime.datetime.now()
     info('--')


### PR DESCRIPTION
Since gogrepo.py downloads the current full installer for the game, I don't want to download and store the patches.
This patch adds a --skippatches flag to omit these downloads.
The manifest has no extra sections for patches, nor any fields to mark them as patch, but GOG names them patch_*, so this flags filters all gamefiles starting with "patch_".