### PR TITLE
Swapped out getheader to headers.get so the script does not error when getting the games xml file

### DIFF
--- a/gogrepo.py
+++ b/gogrepo.py
@@ -364,7 +364,7 @@ def fetch_file_info(d, fetch_md5):
                 tmp_md5_url = "%s.xml" %page.geturl()
                 try:
                     with request(tmp_md5_url) as page:
-                        if page.getheader('Content-Encoding') == 'gzip':
+                        if page.headers.get('Content-Encoding') == 'gzip':
                             shelf_etree = xml.etree.ElementTree.fromstring(gzip.decompress(page.read()))
                         else:
                             shelf_etree = xml.etree.ElementTree.parse(page).getroot()


### PR DESCRIPTION
For whatever reason I could not get this script to work in its orignal form.

I'm not a python dev so I don't know of the best way to do this or even if this PR is done correctly. For whatever it is worth this change allowed the script to work for me.

I came to be using this script because the original one I was using started failing due to XML parsing bugs: https://github.com/eddie3/gogrepo/issues/63