### PR TITLE
GOG gzip compression has broken

### DIFF
--- a/gogrepo.py
+++ b/gogrepo.py
@@ -365,7 +365,9 @@ def fetch_file_info(d, fetch_md5):
                 try:
                     with request(tmp_md5_url) as page:
                         if page.headers.get('Content-Encoding') == 'gzip':
-                            shelf_etree = xml.etree.ElementTree.fromstring(gzip.decompress(page.read()))
+                            buf = StringIO(page.read())
+                            f = gzip.GzipFile(fileobj=buf)
+                            shelf_etree = xml.etree.ElementTree.fromstring(f.read())
                         else:
                             shelf_etree = xml.etree.ElementTree.parse(page).getroot()
                         d.md5 = shelf_etree.attrib['md5']


### PR DESCRIPTION
GOG gzip compression has broken sometime between March and now. For example:

Without gzip
`18:04:57 | successfully found md5 db78d267f55b9cd8061e795f878e1610 for setup_orbit.industries_demo_1.1.9718.0_(64bit)_(55378)-1.bin
18:04:57 | (4 / 7) fetching game details for sanitarium...
18:05:02 | md5 for https://-------------/setup_sanitarium_1.0_hotfix_%2822500%29.exe.xml
18:05:03 | NO GZIP
18:05:03 | successfully found md5 51472f54d7bcaf0dab5c365cf944f398 for setup_sanitarium_1.0_hotfix_(22500).exe`

With gzip
`18:05:09 | (5 / 7) fetching game details for shantae_and_the_pirates_curse...
18:05:13 | md5 for https://-------------/setup_shantae_and_the_pirates_curse_1.04g_%2818994%29.exe.xml
18:05:14 | HAS GZIP
18:05:14 | error
Traceback (most recent call last):
  File "gogrepo.py", line 725, in cmd_update
    filter_downloads(item.downloads, item_json_data['downloads'], lang_list, os_list)
  File "gogrepo.py", line 414, in filter_downloads
    fetch_file_info(d, True)
  File "gogrepo.py", line 370, in fetch_file_info
    shelf_etree = xml.etree.ElementTree.fromstring(gzip.decompress(page.read()))
AttributeError: 'module' object has no attribute 'decompress'`

Note: I have masked the URLs and please ignore the extra debug text I have in the output.

I have no idea what changed or why it is no longer working (I am using Python 2.7.15 (unchanged from March)) and had to change the way the gzip was handled before it could find and verify the MD5. With the changes I now get

`18:17:53 | (1 / 2) fetching game details for shantae_and_the_pirates_curse...
18:17:58 | md5 for https://-------------/setup_shantae_and_the_pirates_curse_1.04g_%2818994%29.exe.xml
18:17:59 | HAS GZIP
18:17:59 | successfully found md5 66e16f3a97328c2ba08c19a64d88c16c for setup_shantae_and_the_pirates_curse_1.04g_(18994).exe`

This was all run with the following command

`python gogrepo.py update -os windows linux -lang en -skipknown`

I was then able to download the files without issue.

The only file I still have problems downloading is the `setup_prison_architect_kite_9502_%2864bit%29_%2856390%29.exe.xml` one that also has a gzip error. I'll save looking at that one until I have more time.

I'm not a Python dev so if there is a better way to do what I have done let me know and I will update when I have time.

Thanks